### PR TITLE
International Date Line Patch

### DIFF
--- a/lib/border_patrol.rb
+++ b/lib/border_patrol.rb
@@ -2,6 +2,16 @@ module BorderPatrol
   class InsufficientPointsToActuallyFormAPolygonError < ArgumentError; end
   class Point < Struct.new(:x, :y); end
 
+  class Point
+    def rechart!
+      if (self.x > 0)
+        self.x -= 180
+      else
+        self.x += 180
+      end
+    end
+  end
+
   def self.parse_kml(string)
     doc = Nokogiri::XML(string)
 

--- a/lib/border_patrol.rb
+++ b/lib/border_patrol.rb
@@ -3,6 +3,10 @@ module BorderPatrol
   class Point < Struct.new(:x, :y); end
 
   class Point
+    # Redefines the coordinates of the point. In the new coordinate system,
+    # points on either side of the International Date Line are close together,
+    # but points on either side of the Prime Meridian are far apart. Applying
+    # #rechart! twice brings you back to the original coordinates
     def rechart!
       if (self.x > 0)
         self.x -= 180

--- a/lib/border_patrol.rb
+++ b/lib/border_patrol.rb
@@ -8,7 +8,7 @@ module BorderPatrol
     # but points on either side of the Prime Meridian are far apart. Applying
     # #rechart! twice brings you back to the original coordinates
     def rechart!
-      if (self.x > 0)
+      if self.x > 0
         self.x -= 180
       else
         self.x += 180

--- a/lib/border_patrol/polygon.rb
+++ b/lib/border_patrol/polygon.rb
@@ -36,6 +36,11 @@ module BorderPatrol
     end
 
     def contains_point?(point)
+      if (cross_intl_date_line?)
+        @points.each{|p| p.rechart!}
+        point.rechart!
+      end
+
       return false unless inside_bounding_box?(point)
       c = false
       i = -1

--- a/lib/border_patrol/polygon.rb
+++ b/lib/border_patrol/polygon.rb
@@ -53,6 +53,18 @@ module BorderPatrol
       return c
     end
 
+    def cross_intl_date_line?
+      i = -1
+      j = self.size - 1
+      while (i += 1) < self.size
+        if ((self[i].x - self[j].x).abs > 180)
+          return true
+        end
+        j = i
+      end
+      return false
+    end
+
     def inside_bounding_box?(point)
       bb_point_1, bb_point_2 = bounding_box
       max_x = [bb_point_1.x, bb_point_2.x].max

--- a/lib/border_patrol/polygon.rb
+++ b/lib/border_patrol/polygon.rb
@@ -3,13 +3,13 @@ module BorderPatrol
   class Polygon
     extend Forwardable
 
-    #If polygon crosses International Date Line, switch to new coordinate system
-    #and indicate this has taken place via @recharted
     def initialize(*args)
       args.flatten!
       args.uniq!
       raise InsufficientPointsToActuallyFormAPolygonError unless args.size > 2
       @points = Array.new(args)
+      #If polygon crosses International Date Line, switch to new coordinate
+      #system and indicate this has taken place via @recharted
       @recharted = initially_cross_intl_date_line?
       @points.each{|p| p.rechart!} if @recharted
     end

--- a/lib/border_patrol/polygon.rb
+++ b/lib/border_patrol/polygon.rb
@@ -36,7 +36,7 @@ module BorderPatrol
     end
 
     def contains_point?(point)
-      if (cross_intl_date_line?)
+      if cross_intl_date_line?
         @points.each{|p| p.rechart!}
         point.rechart!
       end
@@ -62,7 +62,7 @@ module BorderPatrol
       i = -1
       j = self.size - 1
       while (i += 1) < self.size
-        if ((self[i].x - self[j].x).abs > 180)
+        if (self[i].x - self[j].x).abs > 180
           return true
         end
         j = i

--- a/spec/lib/border_patrol/polygon_spec.rb
+++ b/spec/lib/border_patrol/polygon_spec.rb
@@ -115,7 +115,7 @@ describe BorderPatrol::Polygon do
       @polygon.contains_point?(BorderPatrol::Point.new(-20, -20)).should be_false
     end
 
-    it "works for polygons crossing the International Date Line" do
+    it "works for a polygon crossing the International Date Line" do
       points = [BorderPatrol::Point.new(-170, 0), BorderPatrol::Point.new(170, 0), BorderPatrol::Point.new(170, 10),BorderPatrol::Point.new(-170, 10)]
       polygon = BorderPatrol::Polygon.new(points)
       point = BorderPatrol::Point.new(179, 5)
@@ -143,17 +143,17 @@ describe BorderPatrol::Polygon do
 
   end
 
-  describe "#cross_intl_date_line?" do
+  describe "@recharted" do
     it "is false for a polygon not crossing the date line" do
       points = [BorderPatrol::Point.new(-10, 0), BorderPatrol::Point.new(10, 0), BorderPatrol::Point.new(0, 10)]
       polygon = BorderPatrol::Polygon.new(points)
-      polygon.cross_intl_date_line?.should be_false
+      polygon.instance_variable_get(:@recharted).should be_false
     end
 
     it "is true for a polygon crossing the date line" do
       points = [BorderPatrol::Point.new(-170, 0), BorderPatrol::Point.new(170, 0), BorderPatrol::Point.new(170, 10)]
       polygon = BorderPatrol::Polygon.new(points)
-      polygon.cross_intl_date_line?.should be_true
+      polygon.instance_variable_get(:@recharted).should be_true
     end
   end
 end

--- a/spec/lib/border_patrol/polygon_spec.rb
+++ b/spec/lib/border_patrol/polygon_spec.rb
@@ -135,5 +135,19 @@ describe BorderPatrol::Polygon do
     end
 
   end
+
+  describe "#cross_intl_date_line?" do
+    it "is false for a polygon not crossing the date line" do
+      points = [BorderPatrol::Point.new(-10, 0), BorderPatrol::Point.new(10, 0), BorderPatrol::Point.new(0, 10)]
+      polygon = BorderPatrol::Polygon.new(points)
+      polygon.cross_intl_date_line?.should be_false
+    end
+
+    it "is true for a polygon crossing the date line" do
+      points = [BorderPatrol::Point.new(-170, 0), BorderPatrol::Point.new(170, 0), BorderPatrol::Point.new(170, 10)]
+      polygon = BorderPatrol::Polygon.new(points)
+      polygon.cross_intl_date_line?.should be_true
+    end
+  end
 end
 

--- a/spec/lib/border_patrol/polygon_spec.rb
+++ b/spec/lib/border_patrol/polygon_spec.rb
@@ -114,6 +114,13 @@ describe BorderPatrol::Polygon do
       @polygon.contains_point?(BorderPatrol::Point.new(-10, -1)).should be_false
       @polygon.contains_point?(BorderPatrol::Point.new(-20, -20)).should be_false
     end
+
+    it "works for polygons crossing the International Date Line" do
+      points = [BorderPatrol::Point.new(-170, 0), BorderPatrol::Point.new(170, 0), BorderPatrol::Point.new(170, 10),BorderPatrol::Point.new(-170, 10)]
+      polygon = BorderPatrol::Polygon.new(points)
+      point = BorderPatrol::Point.new(179, 5)
+      polygon.contains_point?(point).should be_true
+    end
   end
 
   describe "#inside_bounding_box?" do

--- a/spec/lib/border_patrol_spec.rb
+++ b/spec/lib/border_patrol_spec.rb
@@ -66,5 +66,19 @@ describe BorderPatrol do
         BorderPatrol::Point.new(1,3).should_not == BorderPatrol::Point.new(1.0,2)
       end
     end
+
+    describe "#rechart!" do
+      it "sends x=-1 to x=179" do
+        point = BorderPatrol::Point.new(-1,27)
+        point.rechart!
+        point.should == BorderPatrol::Point.new(179,27)
+      end
+
+      it "sends x=1 to x=-179" do
+        point = BorderPatrol::Point.new(1,27)
+        point.rechart!
+        point.should == BorderPatrol::Point.new(-179,27)
+      end
+    end
   end
 end

--- a/spec/support/cross-line-test.kml
+++ b/spec/support/cross-line-test.kml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://earth.google.com/kml/2.1">
+ <Document>
+  <name>cross_line</name>
+  <description>KML Description</description>
+  <Style id="style1">
+   <LineStyle>
+    <color>990000ff</color>
+    <width>4</width>
+   </LineStyle>
+   <PolyStyle>
+    <color>330000ff</color>
+   </PolyStyle>
+  </Style>
+  <Placemark>
+   <name>Polygon 1</name>
+   <description></description>
+   <styleUrl>#style1</styleUrl>
+   <Polygon>
+    <altitudeMode>relative</altitudeMode>
+    <LinearRing>
+     <coordinates>
+-164.5313,84.2672
+-142.0313,76.5168
+143.4375,76.5168
+-164.5313,84.2672
+    </coordinates>
+    </LinearRing>
+   </Polygon>
+  </Placemark>
+ </Document>
+</kml>


### PR DESCRIPTION
Hi Zach,

I'm a new hire at Square (Risk Team Quant, starting in June).

I thought it would be fun to try and get border_patrol to work for polygons crossing the International Date Line.

I got it to work without having to add too many lines of code. The basic approach is to check if a polygon crosses the IDL when it's created, and change the coordinates of the points to a new coordinate system if it does. The new coordinate system works for polygons crossing the IDL, but not for polygons crossing the Prime Meridian (longitude 0).

I included unit tests with my code. 

It comes at the cost of a minor increase in the benchmark runtime.

Benchmark (kkwteh's code)
                          user     system      total        real
colorado region        0.410000   0.000000   0.410000 (  0.407283)
multi polygon region   1.020000   0.000000   1.020000 (  1.031006)

Benchmark (original code)
                           user     system      total        real
colorado region        0.390000   0.000000   0.390000 (  0.393405)
multi polygon region   0.940000   0.010000   0.950000 (  0.955115)

It might not be at all appropriate for the applications you have in mind, but it might be worth a look.

Cheers,
Kevin
