### PR TITLE
Convert specs to RSpec 2.14.8 syntax using Transpec

### DIFF
--- a/spec/lib/border_patrol/polygon_spec.rb
+++ b/spec/lib/border_patrol/polygon_spec.rb
@@ -7,11 +7,11 @@ describe BorderPatrol::Polygon do
       poly1 = BorderPatrol::Polygon.new(points)
       poly2 = BorderPatrol::Polygon.new(points.unshift(points.pop))
 
-      poly1.should eq(poly2)
-      poly2.should eq(poly1)
+      expect(poly1).to eq(poly2)
+      expect(poly2).to eq(poly1)
       poly3 = BorderPatrol::Polygon.new(points.reverse)
-      poly1.should eq(poly3)
-      poly3.should eq(poly1)
+      expect(poly1).to eq(poly3)
+      expect(poly3).to eq(poly1)
 
     end
 
@@ -21,23 +21,23 @@ describe BorderPatrol::Polygon do
       points = [BorderPatrol::Point.new(5, 5), BorderPatrol::Point.new(1, 2), BorderPatrol::Point.new(0, 0), BorderPatrol::Point.new(3, 4)]
       poly2 = BorderPatrol::Polygon.new(points)
 
-      poly1.should_not eq(poly2)
-      poly2.should_not eq(poly1)
+      expect(poly1).not_to eq(poly2)
+      expect(poly2).not_to eq(poly1)
 
     end
 
     it 'is false if one polygon is a subset' do
       poly1 = BorderPatrol::Polygon.new(BorderPatrol::Point.new(1, 2), BorderPatrol::Point.new(3, 4), BorderPatrol::Point.new(0, 0))
       poly2 = BorderPatrol::Polygon.new(BorderPatrol::Point.new(1, 2), BorderPatrol::Point.new(3, 4), BorderPatrol::Point.new(0, 0), BorderPatrol::Point.new(4, 4))
-      poly2.should_not eq(poly1)
-      poly1.should_not eq(poly2)
+      expect(poly2).not_to eq(poly1)
+      expect(poly1).not_to eq(poly2)
     end
 
     it 'is false if the polygons are not congruent' do
       poly1 = BorderPatrol::Polygon.new(BorderPatrol::Point.new(1, 2), BorderPatrol::Point.new(3, 4), BorderPatrol::Point.new(0, 0))
       poly2 = BorderPatrol::Polygon.new(BorderPatrol::Point.new(2, 1), BorderPatrol::Point.new(3, 4), BorderPatrol::Point.new(0, 0))
-      poly2.should_not eq(poly1)
-      poly1.should_not eq(poly2)
+      expect(poly2).not_to eq(poly1)
+      expect(poly1).not_to eq(poly2)
     end
   end
 
@@ -46,7 +46,7 @@ describe BorderPatrol::Polygon do
       points = [BorderPatrol::Point.new(1, 2), BorderPatrol::Point.new(3, 4), BorderPatrol::Point.new(0, 0)]
       polygon = BorderPatrol::Polygon.new(points)
       points.each do |point|
-        polygon.should include point
+        expect(polygon).to include point
       end
     end
 
@@ -54,7 +54,7 @@ describe BorderPatrol::Polygon do
       points = [BorderPatrol::Point.new(1, 2), BorderPatrol::Point.new(3, 4), BorderPatrol::Point.new(0, 0)]
       poly1 = BorderPatrol::Polygon.new(* points)
       poly2 = BorderPatrol::Polygon.new(points)
-      poly1.should eq(poly2)
+      expect(poly1).to eq(poly2)
     end
 
     it 'raises if less than 3 points are given' do
@@ -70,9 +70,9 @@ describe BorderPatrol::Polygon do
       points = [BorderPatrol::Point.new(1, 2), BorderPatrol::Point.new(3, 4), BorderPatrol::Point.new(0, 0)]
       duplicate_point = [BorderPatrol::Point.new(1, 2)]
       polygon = BorderPatrol::Polygon.new(points + duplicate_point)
-      polygon.size.should eq(3)
+      expect(polygon.size).to eq(3)
       points.each do |point|
-        polygon.should include point
+        expect(polygon).to include point
       end
     end
   end
@@ -81,7 +81,7 @@ describe BorderPatrol::Polygon do
     it 'returns the (max top, max left), (max bottom, max right) as points' do
       points = [BorderPatrol::Point.new(-1, 3), BorderPatrol::Point.new(4, -3), BorderPatrol::Point.new(10, 4), BorderPatrol::Point.new(0, 12)]
       polygon = BorderPatrol::Polygon.new(points)
-      polygon.bounding_box.should eq([BorderPatrol::Point.new(-1, 12), BorderPatrol::Point.new(10, -3)])
+      expect(polygon.bounding_box).to eq([BorderPatrol::Point.new(-1, 12), BorderPatrol::Point.new(10, -3)])
     end
   end
 
@@ -92,27 +92,27 @@ describe BorderPatrol::Polygon do
     end
 
     it 'is true if the point is in the polygon' do
-      @polygon.contains_point?(BorderPatrol::Point.new(0.5, 0.5)).should be_true
-      @polygon.contains_point?(BorderPatrol::Point.new(0, 5)).should be_true
-      @polygon.contains_point?(BorderPatrol::Point.new(-1, 3)).should be_true
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(0.5, 0.5))).to be_true
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(0, 5))).to be_true
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(-1, 3))).to be_true
     end
 
     it 'does not include points on the lines with slopes between vertices' do
-      @polygon.contains_point?(BorderPatrol::Point.new(5.0, 5.0)).should be_false
-      @polygon.contains_point?(BorderPatrol::Point.new(4.999999, 4.9999999)).should be_true
-      @polygon.contains_point?(BorderPatrol::Point.new(0, 0)).should be_true
-      @polygon.contains_point?(BorderPatrol::Point.new(0.000001, 0.000001)).should be_true
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(5.0, 5.0))).to be_false
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(4.999999, 4.9999999))).to be_true
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(0, 0))).to be_true
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(0.000001, 0.000001))).to be_true
     end
 
     it 'includes points at the vertices' do
-      @polygon.contains_point?(BorderPatrol::Point.new(-10, 0)).should be_true
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(-10, 0))).to be_true
     end
 
     it 'is false if the point is outside of the polygon' do
-      @polygon.contains_point?(BorderPatrol::Point.new(9, 5)).should be_false
-      @polygon.contains_point?(BorderPatrol::Point.new(-5, 8)).should be_false
-      @polygon.contains_point?(BorderPatrol::Point.new(-10, -1)).should be_false
-      @polygon.contains_point?(BorderPatrol::Point.new(-20, -20)).should be_false
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(9, 5))).to be_false
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(-5, 8))).to be_false
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(-10, -1))).to be_false
+      expect(@polygon.contains_point?(BorderPatrol::Point.new(-20, -20))).to be_false
     end
   end
 
@@ -123,15 +123,15 @@ describe BorderPatrol::Polygon do
     end
 
     it 'is false if it is outside the bounding box' do
-      @polygon.inside_bounding_box?(BorderPatrol::Point.new(-10, -1)).should be_false
-      @polygon.inside_bounding_box?(BorderPatrol::Point.new(-20, -20)).should be_false
-      @polygon.inside_bounding_box?(BorderPatrol::Point.new(1, 20)).should be_false
+      expect(@polygon.inside_bounding_box?(BorderPatrol::Point.new(-10, -1))).to be_false
+      expect(@polygon.inside_bounding_box?(BorderPatrol::Point.new(-20, -20))).to be_false
+      expect(@polygon.inside_bounding_box?(BorderPatrol::Point.new(1, 20))).to be_false
     end
 
     it 'returns true if it is inside the bounding box' do
-      @polygon.inside_bounding_box?(BorderPatrol::Point.new(9, 5)).should be_true
-      @polygon.inside_bounding_box?(BorderPatrol::Point.new(-5, 8)).should be_true
-      @polygon.inside_bounding_box?(BorderPatrol::Point.new(1, 1)).should be_true
+      expect(@polygon.inside_bounding_box?(BorderPatrol::Point.new(9, 5))).to be_true
+      expect(@polygon.inside_bounding_box?(BorderPatrol::Point.new(-5, 8))).to be_true
+      expect(@polygon.inside_bounding_box?(BorderPatrol::Point.new(1, 1))).to be_true
     end
 
   end
@@ -143,24 +143,24 @@ describe BorderPatrol::Polygon do
     end
 
     it "adds a placemark name to a polygon" do
-      @polygon.placemark_name.should be_nil
+      expect(@polygon.placemark_name).to be_nil
 
       @polygon.with_placemark_name('Twin Peaks, San Francisco')
-      @polygon.placemark_name.should == 'Twin Peaks, San Francisco'
+      expect(@polygon.placemark_name).to eq('Twin Peaks, San Francisco')
     end
 
     it "returns the Polygon object" do
-      @polygon.with_placemark_name('Silverlake, Los Angeles').should equal @polygon
+      expect(@polygon.with_placemark_name('Silverlake, Los Angeles')).to equal @polygon
     end
 
     it "only allows the placemark name to be set once" do
-      @polygon.placemark_name.should be_nil
+      expect(@polygon.placemark_name).to be_nil
 
       @polygon.with_placemark_name('Santa Clara, California')
-      @polygon.placemark_name.should == 'Santa Clara, California'
+      expect(@polygon.placemark_name).to eq('Santa Clara, California')
 
       @polygon.with_placemark_name('Santa Cruz, California')
-      @polygon.placemark_name.should == 'Santa Clara, California'
+      expect(@polygon.placemark_name).to eq('Santa Clara, California')
     end
   end
 end

--- a/spec/lib/border_patrol/region_spec.rb
+++ b/spec/lib/border_patrol/region_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe BorderPatrol::Region do
   it 'is a Set' do
-    BorderPatrol::Region.new.should be_a Set
+    expect(BorderPatrol::Region.new).to be_a Set
   end
 
   it 'stores the polygons provided at initialization' do
     region = BorderPatrol::Region.new([create_polygon, create_polygon(1), create_polygon(2)])
-    region.length.should == 3
+    expect(region.length).to eq(3)
   end
 
   describe '#contains_point?' do
@@ -22,20 +22,20 @@ describe BorderPatrol::Region do
       point = BorderPatrol::Point.new(1, 2)
       @polygons = [create_polygon, create_polygon(30)]
 
-      subject.contains_point?(point).should be_true
+      expect(subject.contains_point?(point)).to be_true
     end
 
     it 'returns false if no polygons contain the point' do
       point = BorderPatrol::Point.new(-1, -2)
       @polygons = [create_polygon, create_polygon(30)]
 
-      subject.contains_point?(point).should be_false
+      expect(subject.contains_point?(point)).to be_false
     end
 
     it 'transforms (x,y) coordinates passed in into a point' do
       @polygons = [create_polygon, create_polygon(30)]
 
-      subject.contains_point?(1, 2).should be_true
+      expect(subject.contains_point?(1, 2)).to be_true
     end
   end
 

--- a/spec/lib/border_patrol_spec.rb
+++ b/spec/lib/border_patrol_spec.rb
@@ -7,16 +7,16 @@ describe BorderPatrol do
     it 'returns a BorderPatrol::Region containing a BorderPatrol::Polygon for each polygon in the KML file' do
       kml_data = File.read(Support_Folder + 'multi-polygon-test.kml')
       region = BorderPatrol.parse_kml(kml_data)
-      region.length.should eq(3)
-      region.each { |p| p.should be_a BorderPatrol::Polygon }
+      expect(region.length).to eq(3)
+      region.each { |p| expect(p).to be_a BorderPatrol::Polygon }
     end
 
     context 'when there is only one polygon' do
       it 'returns a region containing a single polygon' do
         kml_data = File.read(Support_Folder + 'colorado-test.kml')
         region = BorderPatrol.parse_kml(kml_data)
-        region.length.should eq(1)
-        region.each { |p| p.should be_a BorderPatrol::Polygon }
+        expect(region.length).to eq(1)
+        region.each { |p| expect(p).to be_a BorderPatrol::Polygon }
       end
     end
 
@@ -24,8 +24,8 @@ describe BorderPatrol do
       it 'should not care about the xmlns of the <kml> tag' do
         kml_data = File.read(Support_Folder + 'elgin-opengis-ns-test.kml')
         region = BorderPatrol.parse_kml(kml_data)
-        region.length.should eq(7)
-        region.each { |p| p.should be_a BorderPatrol::Polygon }
+        expect(region.length).to eq(7)
+        region.each { |p| expect(p).to be_a BorderPatrol::Polygon }
       end
     end
   end
@@ -48,7 +48,7 @@ describe BorderPatrol do
         </Polygon>
       EOM
       polygon = BorderPatrol.parse_kml_polygon_data(kml)
-      polygon.should eq(BorderPatrol::Polygon.new(BorderPatrol::Point.new(-10, 25), BorderPatrol::Point.new(-1, 30), BorderPatrol::Point.new(10, 1), BorderPatrol::Point.new(0, -5)))
+      expect(polygon).to eq(BorderPatrol::Polygon.new(BorderPatrol::Point.new(-10, 25), BorderPatrol::Point.new(-1, 30), BorderPatrol::Point.new(10, 1), BorderPatrol::Point.new(0, -5)))
     end
   end
 
@@ -59,7 +59,7 @@ describe BorderPatrol do
       polygon_node = doc.search('Polygon').first
 
       placemark_name = BorderPatrol.placemark_name_for_polygon(polygon_node)
-      placemark_name.should == "Shape 1"
+      expect(placemark_name).to eq("Shape 1")
     end
 
     it 'returns the name of the placemark when MultiGeometry is the parent node' do
@@ -68,7 +68,7 @@ describe BorderPatrol do
       polygon_node = doc.search('Polygon').first
 
       placemark_name = BorderPatrol.placemark_name_for_polygon(polygon_node)
-      placemark_name.should == "Elgin"
+      expect(placemark_name).to eq("Elgin")
     end
 
     it 'returns nil when there is no Placemark' do
@@ -97,7 +97,7 @@ describe BorderPatrol do
       polygon_node = doc.search('Polygon').first
 
       placemark_name = BorderPatrol.placemark_name_for_polygon(polygon_node)
-      placemark_name.should be_nil
+      expect(placemark_name).to be_nil
     end
 
     it 'returns a blank string when there is no Placemark name' do
@@ -126,22 +126,22 @@ describe BorderPatrol do
       polygon_node = doc.search('Polygon').first
 
       placemark_name = BorderPatrol.placemark_name_for_polygon(polygon_node)
-      placemark_name.should == ""
+      expect(placemark_name).to eq("")
     end
   end
 
   describe BorderPatrol::Point do
     describe '==' do
       it 'is true if both points contain the same values' do
-        BorderPatrol::Point.new(1, 2).should eq(BorderPatrol::Point.new(1, 2))
+        expect(BorderPatrol::Point.new(1, 2)).to eq(BorderPatrol::Point.new(1, 2))
       end
 
       it 'is true if one point contains floats and one contains integers' do
-        BorderPatrol::Point.new(1, 2.0).should eq(BorderPatrol::Point.new(1.0, 2))
+        expect(BorderPatrol::Point.new(1, 2.0)).to eq(BorderPatrol::Point.new(1.0, 2))
       end
 
       it 'is false if the points contain different values' do
-        BorderPatrol::Point.new(1, 3).should_not eq(BorderPatrol::Point.new(1.0, 2))
+        expect(BorderPatrol::Point.new(1, 3)).not_to eq(BorderPatrol::Point.new(1.0, 2))
       end
     end
   end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 51 conversions
  from: obj.should
    to: expect(obj).to
- 7 conversions
  from: == expected
    to: eq(expected)
- 7 conversions
  from: obj.should_not
    to: expect(obj).not_to
